### PR TITLE
[#105] feat: Lecture 키워드 검색 필터 api 구현

### DIFF
--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/controller/OfflineLectureController.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/controller/OfflineLectureController.java
@@ -34,7 +34,9 @@ public class OfflineLectureController {
     @GetMapping("/courses")
     public ResponseEntity<LectureOfflineListResponse> offlineList(
             @RequestParam(required = false) Integer searchTypeCode,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "") String keyword
+
     ) {
 
         try {
@@ -43,7 +45,8 @@ public class OfflineLectureController {
                     : SearchType.LATELY;
 
             log.info("검색 조건: {} ({})", searchType.getCategorys(), searchType.getCode());
-            LectureOfflineListResponse response = lectureService.offline().getAllLectures(searchType.getCode(), page);
+//            log.info("searchKeyword: {}", searchKeyword);
+            LectureOfflineListResponse response = lectureService.offline().getAllLectures(searchType.getCode(), page,keyword);
             return ResponseEntity.ok().body(response);
         } catch (Exception e){
             log.error("error : {}",e.getMessage());

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/controller/OnlineLectureController.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/controller/OnlineLectureController.java
@@ -33,18 +33,19 @@ public class OnlineLectureController {
     @GetMapping("/courses")
     public ResponseEntity<LectureOnlineListResponse> onlineList(
             @RequestParam(required = false) Integer searchTypeCode,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "") String keyword
     ) {
 
         try{
             SearchType searchType = searchTypeCode != null ?
                     SearchType.fromCode(searchTypeCode)
                     : SearchType.LATELY;
-
+            log.info("Controller.Online.onlineList keyword!!: {}",keyword);
             log.info("검색 조건: {} ({})", searchType.getCategorys(), searchType.getCode());
             LectureOnlineListResponse response = lectureService
                     .online()
-                    .getAllLectures(searchType.getCode(), page);
+                    .getAllLectures(searchType.getCode(), page, keyword);
 
             return ResponseEntity.ok().body(response);
         } catch (CustomException e) {

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/repository/queryDsl/QOfflineLectureRepository.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/repository/queryDsl/QOfflineLectureRepository.java
@@ -5,6 +5,7 @@ import com.mzcteam01.mzcproject01be.domains.lecture.entity.OfflineLecture;
 import com.mzcteam01.mzcproject01be.domains.organization.entity.QOrganization;
 import com.mzcteam01.mzcproject01be.domains.user.entity.QUser;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -39,10 +40,11 @@ public class QOfflineLectureRepository {
     }
 
 
-    public Page<OfflineLecture> findOfflineLectures(Integer SearchType, Pageable pageable) {
+    public Page<OfflineLecture> findOfflineLectures(Integer SearchType, Pageable pageable, String keyword) {
 
         List<OfflineLecture> offline  = queryFactory
                 .selectFrom(offlineLecture)
+                .where(keywordContains(keyword))
                 .orderBy(getCreatedOrder(SearchType, offlineLecture.createdAt))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -73,4 +75,12 @@ public class QOfflineLectureRepository {
                 createdAt.desc() :
                 createdAt.asc();
     }
+    private BooleanExpression keywordContains(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return null;
+        }
+        return offlineLecture.name.containsIgnoreCase(keyword);
+
+    }
+
 }

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/repository/queryDsl/QOnlineLectureRepository.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/repository/queryDsl/QOnlineLectureRepository.java
@@ -4,9 +4,11 @@ import com.mzcteam01.mzcproject01be.domains.lecture.entity.OnlineLecture;
 import com.mzcteam01.mzcproject01be.domains.organization.entity.QOrganization;
 import com.mzcteam01.mzcproject01be.domains.user.entity.QUser;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +19,7 @@ import java.util.Optional;
 
 import static com.mzcteam01.mzcproject01be.domains.lecture.entity.QOnlineLecture.onlineLecture;
 
+@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class QOnlineLectureRepository {
@@ -37,9 +40,11 @@ public class QOnlineLectureRepository {
         );
     }
 
-    public Page<OnlineLecture> findOnlineLectures(Integer SearchType, Pageable pageable) {
+    public Page<OnlineLecture> findOnlineLectures(Integer SearchType, Pageable pageable,String keyword) {
+        log.info("findOnlineLectures start: "+keyword);
         List<OnlineLecture> online = queryFactory
                 .selectFrom(onlineLecture)
+                .where(keywordContains(keyword))
                 .orderBy(getCreatedOrder(SearchType, onlineLecture.createdAt))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -69,4 +74,12 @@ public class QOnlineLectureRepository {
                 createdAt.desc() :
                 createdAt.asc();
     }
+
+    private BooleanExpression keywordContains(String keyword){
+        if(keyword == null || keyword.trim().isEmpty()){
+            return null;
+        }
+        return onlineLecture.name.containsIgnoreCase(keyword);
+    }
+
 }

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/OfflineLectureServiceImpl.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/OfflineLectureServiceImpl.java
@@ -36,16 +36,16 @@ public class OfflineLectureServiceImpl implements OfflineLectureService {
     public List<GetLectureResponse> getTop9Lectures(Integer searchType) {
 
         PageRequest pageRequest = PageRequest.of(0, 9);
-        return qOfflineLectureRepository.findOfflineLectures(searchType, pageRequest)
+        return qOfflineLectureRepository.findOfflineLectures(searchType, pageRequest,null)
                 .stream()
                 .map(GetLectureResponse::of)
                 .toList();
     }
 
     @Override
-    public LectureOfflineListResponse getAllLectures(Integer searchType, int page) {
+    public LectureOfflineListResponse getAllLectures(Integer searchType, int page, String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 20);
-        Page<OfflineLecture> offline = qOfflineLectureRepository.findOfflineLectures(searchType, pageRequest);
+        Page<OfflineLecture> offline = qOfflineLectureRepository.findOfflineLectures(searchType, pageRequest, keyword);
         return LectureOfflineListResponse.of(offline);
     }
 

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/OnlineLectureServiceImpl.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/OnlineLectureServiceImpl.java
@@ -35,7 +35,7 @@ public class OnlineLectureServiceImpl implements OnlineLectureService {
     @Override
     public List<GetLectureResponse> getTop9Lectures(Integer searchType) {
         PageRequest pageRequest = PageRequest.of(0, 9);
-        return qOnlineLectureRepository.findOnlineLectures(searchType, pageRequest)
+        return qOnlineLectureRepository.findOnlineLectures(searchType, pageRequest,null)
                 .stream()
                 .map(GetLectureResponse::of)
                 .toList();
@@ -43,9 +43,9 @@ public class OnlineLectureServiceImpl implements OnlineLectureService {
     }
 
     @Override
-    public LectureOnlineListResponse getAllLectures(Integer searchType, int page) {
+    public LectureOnlineListResponse getAllLectures(Integer searchType, int page, String keyword) {
         PageRequest pageRequest = PageRequest.of(page, 20);
-        Page<OnlineLecture> onlineLecture = qOnlineLectureRepository.findOnlineLectures(searchType, pageRequest);
+        Page<OnlineLecture> onlineLecture = qOnlineLectureRepository.findOnlineLectures(searchType, pageRequest,keyword);
         return LectureOnlineListResponse.of(onlineLecture);
     }
 

--- a/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/interfaces/LectureFacadeService.java
+++ b/src/main/java/com/mzcteam01/mzcproject01be/domains/lecture/service/interfaces/LectureFacadeService.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface LectureFacadeService<T extends Lecture, D, L> {
     D findLecture(int id);
     List<GetLectureResponse> getTop9Lectures(Integer searchType);
-    L getAllLectures(Integer searchType, int page);
+    L getAllLectures(Integer searchType, int page, String keyword);
 }
 

--- a/src/test/java/com/mzcteam01/mzcproject01be/lecture/LectureServiceImplTest.java
+++ b/src/test/java/com/mzcteam01/mzcproject01be/lecture/LectureServiceImplTest.java
@@ -1,6 +1,8 @@
 package com.mzcteam01.mzcproject01be.lecture;
 
-
+import com.mzcteam01.mzcproject01be.domains.lecture.repository.queryDsl.QOfflineLectureRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,5 +10,14 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @Transactional(readOnly = true)
 public class LectureServiceImplTest {
+    @Autowired
+    private QOfflineLectureRepository qOfflineLectureRepository;
+
+    @Test
+    public void QofflineLecture() {
+
+
+
+    }
 
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- search 구현
  
## 📌 작업 내용 및 특이사항
- 키워드에 포함된 강의 name을 기준으로 검색
- 최신순, 날짜 순으로 필터 

